### PR TITLE
Fix trait not found

### DIFF
--- a/src/EventListener/MeListener.php
+++ b/src/EventListener/MeListener.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Webstack\ApiPlatformExtensionsBundle\EventListener;
 
 use ApiPlatform\Api\FormatMatcher;
-use ApiPlatform\Util\ClassInfoTrait;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
@@ -19,6 +18,7 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Webstack\ApiPlatformExtensionsBundle\Util\ClassInfoTrait;
 use Webstack\ApiPlatformExtensionsBundle\Util\MimeType\MimeTypeFlattener;
 
 final class MeListener

--- a/src/Util/ClassInfoTrait.php
+++ b/src/Util/ClassInfoTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webstack\ApiPlatformExtensionsBundle\Util;
+
+use ApiPlatform\Metadata\Util\ClassInfoTrait as MetadataClassInfoTrait;
+use ApiPlatform\Util\ClassInfoTrait as BaseClassInfoTrait;
+
+if (trait_exists(MetadataClassInfoTrait::class)) {
+    trait ClassInfoTrait
+    {
+        use MetadataClassInfoTrait;
+    }
+} elseif (trait_exists(BaseClassInfoTrait::class)) {
+    trait ClassInfoTrait
+    {
+        use BaseClassInfoTrait;
+    }
+}


### PR DESCRIPTION
The exception is `Uncaught ReflectionException: Class "ApiPlatform\Util\ClassInfoTrait" not found while loading "Webstack\ApiPlatformExtensionsBundle\EventListener\MeListener"`

The problem is in api platform 3.1, the trait's namespace changed from `ApiPlatform\Util\ClassInfoTrait` to `ApiPlatform\Metadata\Util\ClassInfoTrait`.

This PR create a new trait, which require more code, but still provide support for `api-platform/core:3.0`. Do we just simply require `api-platform/core:^3.1` and use `ApiPlatform\Metadata\Util\ClassInfoTrait` directly?